### PR TITLE
Dockerfile: Add `USER` as `1001` before hitting entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,5 @@ RUN dotnet publish "qotd-csharp.csproj" -c Release -o /app/publish
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
+USER 1001
 ENTRYPOINT ["dotnet", "qotd-csharp.dll"]


### PR DESCRIPTION
If we build image without this PR and then directly deploy this image as pod in openshift, it is fail with following error.
```
 message: 'container has runAsNonRoot and image will run as root (pod: "qotd-pod_default(daa4fcf5-f918-4bf6-83b8-f5e93f9896f0)",
          container: qotd)'
        reason: CreateContainerConfigError
```
With this PR we make sure the container doesn't run as root user and able to deployed on openshift without any issue.